### PR TITLE
fix: Allow posting updates on locked issues

### DIFF
--- a/.github/workflows/free-dates.yml
+++ b/.github/workflows/free-dates.yml
@@ -13,7 +13,7 @@ jobs:
       - run: yarn install
       - run: yarn free-dates
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NOTIFY_GITHUB_TOKEN }}
           NODE_ENV: "production"
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
       - name: Configure AWS credentials

--- a/.github/workflows/risk-groups.yml
+++ b/.github/workflows/risk-groups.yml
@@ -14,7 +14,7 @@ jobs:
       - run: yarn risk-groups
         env:
           ELIGIBLE_GROUPS_UPDATED_HOOK: ${{ secrets.ELIGIBLE_GROUPS_UPDATED_HOOK }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NOTIFY_GITHUB_TOKEN }}
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
Fix for https://github.community/t/bot-github-actions-not-allowed-to-comment-locked-pr/16766/2