### PR TITLE
feat: display free dates

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,3 +1,8 @@
 /// <reference types="@sveltejs/kit" />
 /// <reference types="svelte" />
 /// <reference types="vite/client" />
+
+// TODO: upstream
+declare module "$app/env" {
+  export const dev: boolean;
+}

--- a/src/lib/EligibleGroups.svelte
+++ b/src/lib/EligibleGroups.svelte
@@ -10,16 +10,17 @@
   const orderedGroups = Object.keys(groups).map((id) => groups[id]);
 </script>
 
-<p>
-  Zuletzt aktualisiert: <time datetime={lastUpdated.toISOString()}
-    >{lastUpdated.toLocaleString()}</time
-  >
-</p>
 <ul>
   {#each orderedGroups as group}
     <li>{group.label}</li>
   {/each}
 </ul>
+
+<p>
+  Zuletzt aktualisiert: <time datetime={lastUpdated.toISOString()}
+    >{lastUpdated.toLocaleString()}</time
+  >
+</p>
 
 <style>
 </style>

--- a/src/lib/FreeDates.svelte
+++ b/src/lib/FreeDates.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  type Centres = Record<string, number>;
+
+  export let ariaLabelledBy: string;
+  export let centres: Centres = {};
+  export let lastUpdated: Date;
+  // Object.entries polyfill
+  const orderedCentres = Object.keys(centres).map((centre) => [
+    centre,
+    centres[centre],
+  ]);
+</script>
+
+<table aria-labelledby={ariaLabelledBy}>
+  <thead>
+    <tr>
+      <th>Impfzentrum</th>
+      <th>Freie Termine</th>
+    </tr></thead
+  >
+  <tbody>
+    {#each orderedCentres as [centre, dates]}
+      <tr
+        ><th class="centre" scope="row">{centre}</th><td class="free-dates"
+          >{dates}</td
+        ></tr
+      >
+    {/each}
+  </tbody>
+</table>
+
+<p>
+  Zuletzt aktualisiert: <time datetime={lastUpdated.toISOString()}
+    >{lastUpdated.toLocaleString()}</time
+  >
+</p>
+
+<p>
+  Daten basierend auf <a
+    href="https://www.countee.ch/app/de/counter/impfee/_iz_sachsen"
+    >https://www.countee.ch/app/de/counter/impfee/_iz_sachsen</a
+  >
+</p>
+
+<style>
+  .centre {
+    text-align: left;
+  }
+
+  .free-dates {
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+  }
+</style>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -8,10 +8,10 @@
 
       // @ts-expect-error https://github.com/sveltejs/kit/issues/691
       if (response.ok) {
-        // @ts-expect-error https://github.com/sveltejs/kit/issues/691
         const {
           groups,
           lastUpdated: lastUpdatedString,
+          // @ts-expect-error https://github.com/sveltejs/kit/issues/691
         } = await response.json();
 
         return {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -59,7 +59,6 @@
 </script>
 
 <script lang="ts">
-  // @ts-expect-error -- TODO
   import { dev } from "$app/env";
   import { onMount } from "svelte";
   import FreeDates from "$lib/FreeDates.svelte";

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -59,7 +59,6 @@
 </script>
 
 <script lang="ts">
-  import { browser } from "$app/env";
   import FreeDates from "$lib/FreeDates.svelte";
   import EligibleGroups from "$lib/EligibleGroups.svelte";
 
@@ -70,38 +69,8 @@
   export let groups: Record<string, EligibleGroup>;
   export let groupsLastUpdated: Date;
 
-  const fetchFreeDates: Promise<{
-    dates: Record<string, number>;
-    lastUpdated: Date;
-  }> = browser
-    ? fetch(
-        "https://vax-notify.s3.eu-central-1.amazonaws.com/data/freeDates.json"
-      ).then(async (response) => {
-        if (!response.ok) {
-          throw new Error(`${response.status}: ${response.statusText}`);
-        }
-        const { lastUpdated, dates } = await response.json();
-
-        return { lastUpdated: new Date(lastUpdated), dates };
-      })
-    : Promise.resolve({
-        dates: {
-          "Bautzen IZ": 134,
-          "Belgern IZ": 213,
-          "Borna IZ": 0,
-          "Chemnitz IZ": 367,
-          "Dresden IZ": 0,
-          "Eich IZ": 620,
-          "Erz IZ": 81,
-          "Leipzig Messe IZ": 1,
-          "Löbau IZ": 618,
-          "Mittweida IZ": 657,
-          "Pirna IZ": 462,
-          "Riesa IZ": 1,
-          "Zwickau IZ": 0,
-        },
-        lastUpdated: new Date(),
-      });
+  export let dates: Record<string, number>;
+  export let datesLastUpdated: Date;
 </script>
 
 <svelte:head>
@@ -116,22 +85,11 @@
   </p>
 
   <h2 id="free-dates-heading">Freie Termine</h2>
-  {#await fetchFreeDates}
-    <p>Freie Termine werden geladen</p>
-  {:then data}
-    <FreeDates
-      ariaLabelledBy="free-dates-heading"
-      centres={data.dates}
-      lastUpdated={data.lastUpdated}
-    />
-  {:catch error}
-    <p>
-      Freie Termine konnten nicht geladen werden. Auf <a
-        href="https://www.countee.ch/app/de/counter/impfee/_iz_sachsen"
-        >Freie Impftermine in Sachsen</a
-      > findest du eine aktuelle Übersicht.
-    </p>
-  {/await}
+  <FreeDates
+    ariaLabelledBy="free-dates-heading"
+    centres={dates}
+    lastUpdated={datesLastUpdated}
+  />
 
   <h2>Berechtigte Gruppen</h2>
   <EligibleGroups {groups} lastUpdated={groupsLastUpdated} />

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -59,6 +59,7 @@
 </script>
 
 <script lang="ts">
+  // @ts-expect-error -- TODO
   import { dev } from "$app/env";
   import { onMount } from "svelte";
   import FreeDates from "$lib/FreeDates.svelte";


### PR DESCRIPTION
The goal is to have stale data pre-rendered that is than hydrated when visiting the site. The docs talk about 
> load is similar to getStaticProps or getServerSideProps in Next.js, except that it runs on both the server and the client.

but it seems to me the fetch is not run on the client.